### PR TITLE
Convert interval to input field, increase maximum

### DIFF
--- a/screenshot-filter.c
+++ b/screenshot-filter.c
@@ -224,8 +224,8 @@ static obs_properties_t *screenshot_filter_properties(void *data)
 	obs_property_set_modified_callback(p_enable_timer,
 					   is_timer_enable_modified);
 
-	obs_properties_add_float_slider(props, SETTING_INTERVAL,
-					"Interval (seconds)", 0.25, 60, 0.25);
+	obs_properties_add_float(props, SETTING_INTERVAL,
+					"Interval (seconds)", 0.25, 86400, 0.25);
 
 	obs_properties_add_bool(props, SETTING_RAW, "Raw image");
 


### PR DESCRIPTION
For use cases that require > 60 seconds it's ideal for interval to be set with an input field