### PR TITLE
CMake parameter definitions for plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 project(obs-screenshot-filter)
+set(PROJECT_FULL_NAME "Screenshot filter")
 
 find_package(FFmpeg REQUIRED COMPONENTS avcodec avutil avformat swscale swresample)
 include_directories(${FFMPEG_INCLUDE_DIRS})
@@ -16,4 +17,5 @@ target_link_libraries(obs-screenshot-filter
       ${FFMPEG_LIBRARIES}
 )
 
+set_target_properties(obs-screenshot-filter PROPERTIES FOLDER "plugins")
 install_obs_plugin_with_data(obs-screenshot-filter data)


### PR DESCRIPTION
Some minor additions to the CMake lists to allow use of this plugin as a submodule when building OBS.

Isolated builds are unaffected by these changes, and this allows for OBS builds to include this plugin as part of a monolithic build process.