### PR TITLE
Update for OBS 29.1.2

### DIFF
--- a/buildspec.json
+++ b/buildspec.json
@@ -1,53 +1,53 @@
 {
     "dependencies": {
         "obs-studio": {
-            "version": "28.0.1",
+            "version": "29.1.2",
             "repository": "https://github.com/obsproject/obs-studio.git",
             "branch": "master",
-            "hash": "e8dc70d0eef4503378d6ac300e680215eb5c9379"
+            "hash": "e15a92e16fc3827027a956f6d6a1223b41aced61"
         },
         "prebuilt": {
-            "version": "2022-08-02",
+            "version": "2023-06-01",
             "baseUrl": "https://github.com/obsproject/obs-deps/releases/download",
             "label": "Pre-built obs-deps",
             "hashes": {
-                "macos-x86_64": "7637e52305e6fc53014b5aabd583f1a4490b1d97450420e977cae9a336a29525",
-                "macos-arm64": "755e0fa69b17a3ae444e1befa9d91d77e3cafe628fbd1c6333686091826595cd",
-                "macos-universal": "de057e73e6fe0825664c258ca2dd6798c41ae580bf4d896e1647676a4941934a",
-                "windows-x64": "2192d8ce780c4281b807cd457994963669e5202659ecd92f19b54c3e7d0c1915",
-                "windows-x86": "9f8582ab5891b000869d6484ea591add9fbac9f1c91b56c7b85fdfd56a261c1b"
+                "macos-x86_64": "fdd3f85f597cb8237041673f4cb0b0908d548791126cfd0d12fa7886bea3745f",
+                "macos-arm64": "17a954636998b07355c66a3d242191bfde75467985cc64ab3c292859b1f54d28",
+                "macos-universal": "ecbfba9473abced9bd16ef2ac29ed61ce036c10a3135039d464a7611daf27fb8",
+                "windows-x64": "cacb858777edaa0251b90350192d175b9b977f186f872a16d1e6b67fc5b4f9f0",
+                "windows-x86": "48ae31f03235ac518af34f44963358222a4236fc7c511c6181eef9e351ca516a"
             }
         },
         "qt5": {
-            "version": "2022-08-02",
+            "version": "2023-06-01",
             "baseUrl": "https://github.com/obsproject/obs-deps/releases/download",
             "label": "Pre-built Qt5",
             "hashes": {
-                "macos-x86_64": "3d0381a52b0e4d49967936c4357f79ac711f43564329304a6db5c90edadd2697",
-                "macos-arm64": "f4b32548c0530f121956bf0a9a70c36ecbbfca81073d39c396a1759baf2a05c3",
-                "macos-universal": "9a6cf3b9a6c9efee6ba10df649202e8075e99f3c54ae88dc9a36dbc9d7471c1e",
-                "windows-x64": "6488a33a474f750d5a4a268a5e20c78bb40799d99136a1b7ce3365a843cb2fd7",
-                "windows-x86": "a916e09b0a874036801deab2c8a7ec14fdf5d268aa5511eac5bf40727e0c4e33"
+                "macos-x86_64": "3efa1a0a49b3f009401d9dd76032c2d228f70baf725ffeb039ff98fd5d83cc3c",
+                "macos-arm64": "4b9106867d47c0b4b9130e34830c074b22e607cc3cda6788316aec2b857b0ce4",
+                "macos-universal": "7fed45bdd5b5517ad93e8919a2105330d204d44cfcf257cefea86d5927ddef45",
+                "windows-x64": "99d6af1a784bc43dfea9d5bef1e8f9db88bd4d314f2e68bae86e972c73628639",
+                "windows-x86": "266ce0708d682a577853f7cc8b4c2bb3568fc73e20296e6fbd7714ea9f6776ad"
             },
             "pdb-hashes": {
-                "windows-x64": "e0e5070143fcad9311a68ce5685d8ba8f34f581ed6942b7a92d360f94ca1ba11",
-                "windows-x86": "36642d1052aa461964f46c17610477b0d9b9defbe2d745ccaacb85f805c1bec2"
+                "windows-x64": "7d955aca2b2976f9e085040795f5642b3cac1f76c5534a47fe8e6c6cf351a4fb",
+                "windows-x86": "83ec785e12eb67cd1d57ec9ec91db2eb737b6a3fde09049a1aeb59260aec1a0d"
             }
         },
         "qt6": {
-            "version": "2022-08-02",
+            "version": "2023-06-01",
             "baseUrl": "https://github.com/obsproject/obs-deps/releases/download",
             "label": "Pre-built Qt6",
             "hashes": {
-                "macos-x86_64": "a83f72a11023b03b6cb2dc365f0a66ad9df31163bbb4fe2df32d601856a9fad3",
-                "macos-arm64": "2f30af90c049670a5660656adbb440668aa1b0567f75a5f29e1def9108928403",
-                "macos-universal": "252e6684f43ab9c6f262c73af739e2296ce391b998da2c4ee04c254aaa07db18",
-                "windows-x64": "e5509b54196a3f935250cc4b9c54160c8e588fd0f92bc078a2a64f9d9e2e4e93",
-                "windows-x86": "24fc03bef153a0e027c1479e42eb08097a4ea1d70a4710825be0783d0626cb0d"
+                "macos-x86_64": "b874b9aefbb42e586661c8cc652c889413dd68ff683307de54af8074139e69ab",
+                "macos-arm64": "e95d6461b8cafea6125aa82e3f9888eea5c5101a3911e88543631fadeb5faa9f",
+                "macos-universal": "5c1880af8fe8e6a0e85924952e8c756410c37e6f13e36667be86cd0979a2ae8b",
+                "windows-x64": "aa77caa98d34263a97e0bd0435a18e5c981e915636af562557bb4bf09d49be04",
+                "windows-x86": "def9f9aa929eda36a10bf969c8dfef6f6ecac71bc30c4ef579063250899f93d3"
             },
             "pdb-hashes": {
-                "windows-x64": "60e5b1d2bc4d7c431bc05f14e3b1e85e088788c372fa85f58717cd6c49555a46",
-                "windows-x86": "f34d1a89fc85d92913bd6c7f75ec5c28471d74db708c98161100bc8b75f8fc63"
+                "windows-x64": "7d955aca2b2976f9e085040795f5642b3cac1f76c5534a47fe8e6c6cf351a4fb",
+                "windows-x86": "0b805605621854baf64b539871801412bf87b12579133e99c1235ce3096eb4a5"
             }
         }
     },


### PR DESCRIPTION
Update `obs-studio` to 29.1.2 and `obs-deps` to the version that ships with 29.1.2. 

It appears that this plugin broke in OBS 29 due to the obs bundled libav version changing from 58 to 60. 